### PR TITLE
copy more common scripts to root folder. 

### DIFF
--- a/cmd_count_nb_jobs_masispiderdev.txt
+++ b/cmd_count_nb_jobs_masispiderdev.txt
@@ -1,0 +1,1 @@
+squeue -u masispiderdev --noheader | wc -l

--- a/cmd_count_nb_jobs_vuiisccidev.txt
+++ b/cmd_count_nb_jobs_vuiisccidev.txt
@@ -1,0 +1,1 @@
+squeue -u vuiisccidev --noheader | wc -l

--- a/cmd_get_job_memory.txt
+++ b/cmd_get_job_memory.txt
@@ -1,0 +1,1 @@
+sacct -j ${jobid}.batch --format MaxRss --noheader | awk '{print $1+0}'

--- a/cmd_get_job_node.txt
+++ b/cmd_get_job_node.txt
@@ -1,0 +1,1 @@
+sacct -j ${jobid}.batch --format NodeList --noheader

--- a/cmd_get_job_status.txt
+++ b/cmd_get_job_status.txt
@@ -1,0 +1,1 @@
+squeue -j ${jobid} --noheader | awk {'print $5'}

--- a/cmd_get_job_walltime.txt
+++ b/cmd_get_job_walltime.txt
@@ -1,0 +1,1 @@
+sacct -j ${jobid}.batch --format CPUTime --noheader


### PR DESCRIPTION
cmd_count_nb_jobs needs to be separated.